### PR TITLE
openhab 2.5 code clean

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/pom.xml
+++ b/pom.xml
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.megad</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: MegaD Binding</name>
 
-<dependencies>
-<dependency>
-    <groupId>commons-codec</groupId>
-    <artifactId>commons-codec</artifactId>
-    <version>1.6</version>
-</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.6</version>
+    </dependency>
 
-</dependencies>
+  </dependencies>
 
 
 </project>

--- a/src/main/feature/feature.xml
+++ b/src/main/feature/feature.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.megad-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-    <feature name="openhab-binding-megad" description="MegaD Binding" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.megad/${project.version}</bundle>
-    </feature>
+	<feature name="openhab-binding-megad" description="MegaD Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.megad/${project.version}</bundle>
+	</feature>
 </features>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.5.0" name="org.openhab.binding.megad-2.5.0-SNAPSHOT">
-    <feature version="0.0.0">
-        <feature>openhab-runtime-base</feature>
-        <bundle>mvn:commons-codec/commons-codec/1.6</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.megad/2.5.0-SNAPSHOT</bundle>
-    </feature>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.binding.megad-2.5.2-SNAPSHOT">
+	<feature version="0.0.0">
+		<feature>openhab-runtime-base</feature>
+		<bundle>mvn:commons-codec/commons-codec/1.6</bundle>
+		<bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.megad/2.5.2-SNAPSHOT</bundle>
+	</feature>
 </features>

--- a/src/main/java/org/openhab/binding/megad/MegaDBindingConstants.java
+++ b/src/main/java/org/openhab/binding/megad/MegaDBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/java/org/openhab/binding/megad/MegaDConfiguration.java
+++ b/src/main/java/org/openhab/binding/megad/MegaDConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -184,7 +184,7 @@ public class MegaDHandler extends BaseThingHandler {
                             updateState(channel.getUID().getId(), OnOffType.OFF);
                         }
                     } catch (Exception e) {
-                        logger.debug(" Not m2 signal ", e.getLocalizedMessage());
+                        logger.debug(" Not m2 signal: {}", e.getLocalizedMessage());
                     }
 
                 } else if (channel.getUID().getId().equals(MegaDBindingConstants.CHANNEL_CLICK)) {
@@ -193,7 +193,7 @@ public class MegaDHandler extends BaseThingHandler {
                         try {
                             updateState(channel.getUID().getId(), DecimalType.valueOf(getCommands[4]));
                         } catch (Exception ex) {
-                            logger.debug(" Cannot update click ", ex.getLocalizedMessage());
+                            logger.debug(" Cannot update click: {} ", ex.getLocalizedMessage());
                         }
                     }
 
@@ -493,7 +493,7 @@ public class MegaDHandler extends BaseThingHandler {
     private synchronized @Nullable MegaDBridgeHandler getBridgeHandler() {
         Bridge bridge = getBridge();
         if (bridge == null) {
-            logger.error("Required bridge not defined for device {}.");
+            logger.error("Required bridge not defined for device.");
             // throw new NullPointerException("Required bridge not defined for device");
             return null;
         } else {

--- a/src/main/java/org/openhab/binding/megad/i2c/I2C.java
+++ b/src/main/java/org/openhab/binding/megad/i2c/I2C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -102,9 +102,9 @@ public class I2C {
             }
             con.disconnect();
         } catch (MalformedURLException e) {
-            logger.error("1 - {}", e);
+            logger.error("1 - {}", e.getLocalizedMessage());
         } catch (ProtocolException e) {
-            logger.error("2 - {}", e);
+            logger.error("2 - {}", e.getLocalizedMessage());
         } catch (IOException e) {
             logger.error("Connect to megadevice {} error: {}", host, e.getLocalizedMessage());
         }

--- a/src/main/java/org/openhab/binding/megad/internal/MegaDHandlerFactory.java
+++ b/src/main/java/org/openhab/binding/megad/internal/MegaDHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/resources/ESH-INF/binding/binding.xml
+++ b/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="megad"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+<binding:binding id="megad" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-    <name>MegaD Binding</name>
-    <description>This is the binding for MegaDevice.</description>
-    <author>Petr Shatsillo</author>
+	<name>MegaD Binding</name>
+	<description>This is the binding for MegaDevice.</description>
+	<author>Petr Shatsillo</author>
 
 </binding:binding>

--- a/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/src/main/resources/ESH-INF/thing/bridge.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="megad"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="bridge">
 		<label>Bridge Megad incoming server adapter</label>
-		<description>This bridge represents incoming server for MegaD 
+		<description>This bridge represents incoming server for MegaD
 		</description>
 
 		<config-description>
-			<parameter name="port" type="integer" required="true" min="1024"
-				max="49151">
-				<context>network-address</context>
+			<parameter name="port" type="integer" required="true" min="1024" max="49151">
 				<label>MegaD server port</label>
 				<description>Port of the LAN gateway</description>
 				<default>0</default>

--- a/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="megad" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="megad"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 
 	<thing-type id="device">
@@ -76,9 +77,9 @@
 
 
 	<channel-type id="in">
-	 	<item-type>Switch</item-type>
+		<item-type>Switch</item-type>
 		<label>Input</label>
-		<description>Port set as  input signal for switch using</description>
+		<description>Port set as input signal for switch using</description>
 	</channel-type>
 	<channel-type id="incount">
 		<item-type>Number</item-type>
@@ -91,15 +92,15 @@
 		<description>Port set as output for switch using</description>
 	</channel-type>
 	<channel-type id="m2signal">
-        <item-type>Switch</item-type>
-        <label>Long press switch</label>
-        <description>React if long press from mega detected</description>
-    </channel-type>
-    <channel-type id="click">
-        <item-type>Number</item-type>
-        <label>Click</label>
-        <description>Counter, reacts if click mode enabled in megad</description>
-    </channel-type>
+		<item-type>Switch</item-type>
+		<label>Long press switch</label>
+		<description>React if long press from mega detected</description>
+	</channel-type>
+	<channel-type id="click">
+		<item-type>Number</item-type>
+		<label>Click</label>
+		<description>Counter, reacts if click mode enabled in megad</description>
+	</channel-type>
 	<channel-type id="dimmer">
 		<item-type>Dimmer</item-type>
 		<label>Dimmer</label>
@@ -176,14 +177,14 @@
 		<label>i2cdisplay</label>
 		<description>i2cdisplay </description>
 		<state readOnly="true" pattern="%s"></state>
-    </channel-type>
-		<channel-type id="smsphone">
+	</channel-type>
+	<channel-type id="smsphone">
 		<item-type>String</item-type>
 		<label>sms_phone</label>
 		<description>sms_phone</description>
 		<state readOnly="true"></state>
 	</channel-type>
-		<channel-type id="smstext">
+	<channel-type id="smstext">
 		<item-type>String</item-type>
 		<label>sms_text</label>
 		<description>sms_text</description>


### PR DESCRIPTION
Just made code cleanup based on openhab tests recommendations - now it's possible to run "mvn clean install -pl :org.openhab.binding.megad" with all the tests.