### PR TITLE
Add ds2413 support #17

### DIFF
--- a/src/main/java/org/openhab/binding/megad/MegaDBindingConstants.java
+++ b/src/main/java/org/openhab/binding/megad/MegaDBindingConstants.java
@@ -39,6 +39,7 @@ public class MegaDBindingConstants {
     public static final String CHANNEL_M2 = "m2signal";
     public static final String CHANNEL_CLICK = "click";
     public static final String CHANNEL_OUT = "out";
+    public static final String CHANNEL_DS2413 = "ds2413";
     public static final String CHANNEL_DIMMER = "dimmer";
     public static final String CHANNEL_DHTTEMP = "temp";
     public static final String CHANNEL_DHTHUM = "humidity";

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDHandler.java
@@ -81,6 +81,19 @@ public class MegaDHandler extends BaseThingHandler {
                     + getThing().getConfiguration().get("port").toString() + ":" + state;
             logger.info("Switch: {}", result);
             sendCommand(result);
+        } else if (channelUID.getId().equals(MegaDBindingConstants.CHANNEL_DS2413)) {
+            if (command.toString().equals("ON")) {
+                state = 1;
+            } else if (command.toString().equals("OFF")) {
+                state = 0;
+            }
+            result = "http://" + getThing().getConfiguration().get("hostname").toString() + "/"
+                    + getThing().getConfiguration().get("password").toString() + "/?cmd="
+                    + getThing().getConfiguration().get("port").toString()
+                    + getThing().getConfiguration().get("ds2413_ch")
+                    + ":" + state;
+            logger.info("Switch: {}", result);
+            sendCommand(result);
         } else if (channelUID.getId().equals(MegaDBindingConstants.CHANNEL_DIMMER)) {
             if (!command.toString().equals("REFRESH")) {
                 try {

--- a/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -18,6 +18,7 @@
 			<channel id="in" typeId="in" />
 			<channel id="incount" typeId="incount"></channel>
 			<channel id="out" typeId="out"></channel>
+			<channel id="ds2413" typeId="ds2413"></channel>
 			<channel id="m2signal" typeId="m2signal"></channel>
 			<channel id="click" typeId="click"></channel>
 			<channel id="dimmer" typeId="dimmer"></channel>
@@ -70,6 +71,10 @@
 				<label>I2C Parameter</label>
 				<description>Only for i2c</description>
 			</parameter>
+			<parameter name="ds2413_ch" type="text">
+				<label>DS2413 channel name</label>
+				<description>Only for DS2413</description>
+			</parameter>
 		</config-description>
 
 	</thing-type>
@@ -90,6 +95,11 @@
 		<item-type>Switch</item-type>
 		<label>Output</label>
 		<description>Port set as output for switch using</description>
+	</channel-type>
+	<channel-type id="ds2413">
+		<item-type>Switch</item-type>
+		<label>Output</label>
+		<description>Port set as output for ds2413-based two-channel switch</description>
 	</channel-type>
 	<channel-type id="m2signal">
 		<item-type>Switch</item-type>


### PR DESCRIPTION
New channel type: ds2413
New thing param:  ds2413_ch
ds2413_ch could be either "A" or "B"
Works just like regular out channel

Proposal for #17
This implementation works, but after it sends ds2413 command, it also sends regular out command
```
==> openhab_userdata/logs/events.log <==
2020-01-26 15:23:16.652 [ome.event.ItemCommandEvent] - Item 'button_heat_window' received command OFF

==> openhab_userdata/logs/openhab.log <==
2020-01-26 15:23:16.661 [INFO ] [b.binding.megad.handler.MegaDHandler] - Switch: http://192.168.0.14/sec/?cmd=1A:0

==> openhab_userdata/logs/events.log <==
2020-01-26 15:23:16.667 [nt.ItemStatePredictedEvent] - button_heat_window predicted to become OFF
2020-01-26 15:23:16.691 [vent.ItemStateChangedEvent] - button_heat_window changed from ON to OFF

==> openhab_userdata/logs/openhab.log <==
2020-01-26 15:23:16.700 [INFO ] [b.binding.megad.handler.MegaDHandler] - Switch: http://192.168.0.14/sec/?cmd=1:0
```