### PR TITLE
Fix and Optimization PCA9685

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -28,5 +28,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -18,11 +18,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 org.openhab.binding.megad.iml
+/.history/
+.classpath

--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1618042301358</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
@@ -274,9 +274,12 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
                 }
             }
             if (extenderPCA9685BridgeHandlerMap.size() != 0) {
-                extenderPCA9685BridgeHandlerMap.forEach((k, v) -> {
-                    v.updateValues(getCommands);
-                });
+                // PCA9685 Don`t have extender input
+                /*
+                 * extenderPCA9685BridgeHandlerMap.forEach((k, v) -> {
+                 * v.updateValues(getCommands);
+                 * });
+                 */
             }
             if (megaDEncoderHandlerMap.size() != 0) {
                 megaDEncoderHandler = megaDEncoderHandlerMap.get(getCommands[1]);

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
@@ -437,18 +437,11 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
     public void registerMegaDBridgeExtenderPCA9685Listener(MegaDBridgeExtenderPCA9685Handler bridge) {
         String port = bridge.getThing().getConfiguration().get("port").toString();
         if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
-            updateThingHandlerStatus(
-				bridge,
-				ThingStatus.OFFLINE,
-				ThingStatusDetail.CONFIGURATION_ERROR,
-                "Device already exist"
-			);
+            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Device already exist");
         } else {
             extenderPCA9685BridgeHandlerMap.put(port, bridge);
-            updateThingHandlerStatus(
-				bridge,
-				ThingStatus.ONLINE
-			);
+            updateThingHandlerStatus(bridge, ThingStatus.ONLINE);
         }
     }
 
@@ -457,10 +450,7 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
         String port = bridge.getThing().getConfiguration().get("port").toString();
         if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
             extenderPCA9685BridgeHandlerMap.remove(port);
-            updateThingHandlerStatus(
-				bridge,
-				ThingStatus.OFFLINE
-			);
+            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE);
         }
     }
 

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
@@ -434,25 +434,23 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
 
     // PCA9685
     @SuppressWarnings({ "unused", "null" })
-    public void registerMegaExtenderPCA9685Listener(
-            MegaDBridgeExtenderPCA9685Handler megaDBridgeExtenderPCA9685Handler) {
-        String extenderPort = megaDBridgeExtenderPCA9685Handler.getThing().getConfiguration().get("port").toString();
-        if (extenderPCA9685BridgeHandlerMap.get(extenderPort) != null) {
-            updateThingHandlerStatus(megaDBridgeExtenderPCA9685Handler, ThingStatus.OFFLINE,
+    public void registerMegaDBridgeExtenderPCA9685Listener(MegaDBridgeExtenderPCA9685Handler bridge) {
+        String port = bridge.getThing().getConfiguration().get("port").toString();
+        if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
+            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE,
                     ThingStatusDetail.CONFIGURATION_ERROR, "Device already exist");
         } else {
-            extenderPCA9685BridgeHandlerMap.put(extenderPort, megaDBridgeExtenderPCA9685Handler);
-            updateThingHandlerStatus(megaDBridgeExtenderPCA9685Handler, ThingStatus.ONLINE);
+            extenderPCA9685BridgeHandlerMap.put(port, bridge);
+            updateThingHandlerStatus(bridge, ThingStatus.ONLINE);
         }
     }
 
     @SuppressWarnings("null")
-    public void unregisterMegaExtenderPCA9685Listener(
-            MegaDBridgeExtenderPCA9685Handler megaDBridgeExtenderPCA9685Handler) {
-        String extenderPort = megaDBridgeExtenderPCA9685Handler.getThing().getConfiguration().get("port").toString();
-        if (extenderPCA9685BridgeHandlerMap.get(extenderPort) != null) {
-            extenderPCA9685BridgeHandlerMap.remove(extenderPort);
-            updateThingHandlerStatus(megaDBridgeExtenderPCA9685Handler, ThingStatus.OFFLINE);
+    public void unregisterMegaDBridgeExtenderPCA9685Listener(MegaDBridgeExtenderPCA9685Handler bridge) {
+        String port = bridge.getThing().getConfiguration().get("port").toString();
+        if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
+            extenderPCA9685BridgeHandlerMap.remove(port);
+            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE);
         }
     }
 

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeDeviceHandler.java
@@ -437,11 +437,18 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
     public void registerMegaDBridgeExtenderPCA9685Listener(MegaDBridgeExtenderPCA9685Handler bridge) {
         String port = bridge.getThing().getConfiguration().get("port").toString();
         if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
-            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE,
-                    ThingStatusDetail.CONFIGURATION_ERROR, "Device already exist");
+            updateThingHandlerStatus(
+				bridge,
+				ThingStatus.OFFLINE,
+				ThingStatusDetail.CONFIGURATION_ERROR,
+                "Device already exist"
+			);
         } else {
             extenderPCA9685BridgeHandlerMap.put(port, bridge);
-            updateThingHandlerStatus(bridge, ThingStatus.ONLINE);
+            updateThingHandlerStatus(
+				bridge,
+				ThingStatus.ONLINE
+			);
         }
     }
 
@@ -450,7 +457,10 @@ public class MegaDBridgeDeviceHandler extends BaseBridgeHandler {
         String port = bridge.getThing().getConfiguration().get("port").toString();
         if (extenderPCA9685BridgeHandlerMap.get(port) != null) {
             extenderPCA9685BridgeHandlerMap.remove(port);
-            updateThingHandlerStatus(bridge, ThingStatus.OFFLINE);
+            updateThingHandlerStatus(
+				bridge,
+				ThingStatus.OFFLINE
+			);
         }
     }
 

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeExtenderPCA9685Handler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeExtenderPCA9685Handler.java
@@ -93,7 +93,6 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
 
     @SuppressWarnings("null")
     public void updateValues(String[] getCommands) {
-        logger.info(getCommands.toString());
         String port = getCommands[2].substring(3);
         String action = getCommands[3];
         Thing = mapThings.get(String.valueOf(port));

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeExtenderPCA9685Handler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDBridgeExtenderPCA9685Handler.java
@@ -27,14 +27,14 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
     @Nullable
-    MegaDBridgeDeviceHandler bridgeDeviceHandler;
+    MegaDBridgeDeviceHandler BridgeDevice;
     private Logger logger = LoggerFactory.getLogger(MegaDBridgeExtenderPCA9685Handler.class);
-    private Map<String, MegaDExtenderPCA9685Handler> extenderPCA9685HandlerMap = new HashMap<String, MegaDExtenderPCA9685Handler>();
+    private Map<String, MegaDExtenderPCA9685Handler> mapThings = new HashMap<String, MegaDExtenderPCA9685Handler>();
     private boolean startedState = false;
     private @Nullable ScheduledFuture<?> refreshPollingJob;
     protected long lastRefresh = 0;
     @Nullable
-    MegaDExtenderPCA9685Handler MegaDExtenderPCA9685Handler;
+    MegaDExtenderPCA9685Handler Thing;
 
     public MegaDBridgeExtenderPCA9685Handler(Bridge bridge) {
         super(bridge);
@@ -47,23 +47,24 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
     @SuppressWarnings({ "unused", "null" })
     @Override
     public void initialize() {
-        bridgeDeviceHandler = getBridgeHandler();
-        if (bridgeDeviceHandler != null) {
-            registerMegaExtenderPCA9685BridgeListener(bridgeDeviceHandler);
-        } else {
-            logger.debug("Can't register {} at bridge. BridgeHandler is null.", this.getThing().getUID());
-        }
-        String[] rr = { getThing().getConfiguration().get("refresh").toString() };// .split("[.]");
-        logger.debug("Thing {}, refresh interval is {} sec", getThing().getUID().toString(), rr[0]);
-        float msec = Float.parseFloat(rr[0]);
+        BridgeDevice = getBridgeHandler();
+		registerListenerBridge(BridgeDevice);
+        String refresh = getThing().getConfiguration().get("refresh").toString();
+        logger.debug("Thing {}, refresh interval is {} sec", getThing().getUID().toString(), refresh);
+        float msec = Float.parseFloat(refresh);
         int pollingPeriod = (int) (msec * 1000);
         if (refreshPollingJob == null || refreshPollingJob.isCancelled()) {
-            refreshPollingJob = scheduler.scheduleWithFixedDelay(new Runnable() {
-                @Override
-                public void run() {
-                    refresh(pollingPeriod);
-                }
-            }, 0, 100, TimeUnit.MILLISECONDS);
+            refreshPollingJob = scheduler.scheduleWithFixedDelay(
+				new Runnable() {
+					@Override
+					public void run() {
+						refresh(pollingPeriod);
+					}
+				},
+				0,
+				100,
+				TimeUnit.MILLISECONDS
+			);
         }
     }
 
@@ -72,7 +73,7 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
         long now = System.currentTimeMillis();
         if (interval != 0) {
             if (now >= (lastRefresh + interval)) {
-                extenderPCA9685HandlerMap.forEach((k, v) -> {
+                mapThings.forEach((k, v) -> {
                     v.updateData(k);
                 });
                 setStateStarted(true);
@@ -85,8 +86,8 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
     public void updateValues(String[] getCommands) {
         String port = getCommands[2].substring(3);
         String action = getCommands[3];
-        MegaDExtenderPCA9685Handler = extenderPCA9685HandlerMap.get(String.valueOf(port));
-        MegaDExtenderPCA9685Handler.updateValues(action);
+        Thing = mapThings.get(String.valueOf(port));
+        Thing.updateValues(action);
         logger.warn("Required bridge not defined for device.");
     }
 
@@ -118,46 +119,57 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
         }
     }
 
-    private void registerMegaExtenderPCA9685BridgeListener(@Nullable MegaDBridgeDeviceHandler bridgeDeviceHandler) {
-        if (bridgeDeviceHandler != null) {
-            bridgeDeviceHandler.registerMegaExtenderPCA9685Listener(this);
-        }
+    private void registerListenerBridge(@Nullable MegaDBridgeDeviceHandler bridgeDevice) {
+        if (bridgeDevice != null) {
+            bridgeDevice.registerMegaDBridgeExtenderPCA9685Listener(this);
+        } else {
+			logger.debug("Can't register {} at bridge. BridgeHandler is null.", this.getThing().getUID());
+		}
     }
 
     @SuppressWarnings({ "unused", "null" })
-    public void registerExtenderPCA9685Listener(MegaDExtenderPCA9685Handler megaDExtenderPCA9685Handler) {
-        String extport = megaDExtenderPCA9685Handler.getThing().getConfiguration().get("extport").toString();
-        if (extenderPCA9685HandlerMap.get(extport) != null) {
-            updateThingHandlerStatus(megaDExtenderPCA9685Handler, ThingStatus.OFFLINE,
-                    ThingStatusDetail.CONFIGURATION_ERROR, "port already exists");
+    public void registerListenerThing(MegaDExtenderPCA9685Handler thing) {
+        String extport = thing.getThing().getConfiguration().get("extport").toString();
+        if (mapThings.get(extport) != null) {
+            updateThingStatus(
+				thing,
+				ThingStatus.OFFLINE,
+                ThingStatusDetail.CONFIGURATION_ERROR,
+				"port already exists"
+			);
         } else {
-            extenderPCA9685HandlerMap.put(extport, megaDExtenderPCA9685Handler);
-            updateThingHandlerStatus(megaDExtenderPCA9685Handler, ThingStatus.ONLINE);
+            mapThings.put(extport, thing);
+            updateThingStatus(
+				thing,
+				ThingStatus.ONLINE
+			);
         }
     }
 
     @SuppressWarnings("null")
-    public void unregisterExtenderPCA9685Listener(@Nullable MegaDExtenderPCA9685Handler megaDExtenderPCA9685Handler) {
-        String extport = megaDExtenderPCA9685Handler.getThing().getConfiguration().get("extport").toString();
-        if (extenderPCA9685HandlerMap.get(extport) != null) {
-            extenderPCA9685HandlerMap.remove(extport);
-            updateThingHandlerStatus(megaDExtenderPCA9685Handler, ThingStatus.OFFLINE);
+    public void unregisterListenerThing(@Nullable MegaDExtenderPCA9685Handler thing) {
+        String extport = thing.getThing().getConfiguration().get("extport").toString();
+        if (mapThings.get(extport) != null) {
+            mapThings.remove(extport);
+            updateThingStatus(
+				thing,
+				ThingStatus.OFFLINE
+			);
         }
     }
 
-    private void updateThingHandlerStatus(MegaDExtenderPCA9685Handler thingHandler, ThingStatus status) {
-        thingHandler.updateStatus(status);
+    private void updateThingStatus(MegaDExtenderPCA9685Handler thing, ThingStatus status) {
+        thing.updateStatus(status);
     }
 
-    private void updateThingHandlerStatus(MegaDExtenderPCA9685Handler megaDExtenderPCA9685Handler, ThingStatus status,
-            ThingStatusDetail statusDetail, String decript) {
-        megaDExtenderPCA9685Handler.updateStatus(status, statusDetail, decript);
+    private void updateThingStatus(MegaDExtenderPCA9685Handler thing, ThingStatus status, ThingStatusDetail statusDetail, String decript) {
+		thing.updateStatus(status, statusDetail, decript);
     }
 
     @SuppressWarnings("null")
     public String[] getHostPassword() {
-        String[] result = new String[] { bridgeDeviceHandler.getThing().getConfiguration().get("hostname").toString(),
-                bridgeDeviceHandler.getThing().getConfiguration().get("password").toString() };
+        String[] result = new String[] { BridgeDevice.getThing().getConfiguration().get("hostname").toString(),
+			BridgeDevice.getThing().getConfiguration().get("password").toString() };
         return result;
     }
 
@@ -178,8 +190,8 @@ public class MegaDBridgeExtenderPCA9685Handler extends BaseBridgeHandler {
             refreshPollingJob.cancel(true);
             refreshPollingJob = null;
         }
-        if (bridgeDeviceHandler != null) {
-            bridgeDeviceHandler.unregisterMegaExtenderPCA9685Listener(this);
+        if (BridgeDevice != null) {
+            BridgeDevice.unregisterMegaDBridgeExtenderPCA9685Listener(this);
         }
         super.dispose();
     }

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDExtenderPCA9685Handler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDExtenderPCA9685Handler.java
@@ -58,14 +58,14 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
     @SuppressWarnings("null")
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-		String strCommand = command.toString();
+        String strCommand = command.toString();
         if (!strCommand.equals("REFRESH")) {
-			String hostname = Bridge.getHostPassword()[0];
-			String password = Bridge.getHostPassword()[1];
-			String port = Bridge.getThing().getConfiguration().get("port").toString();
-			String extport = getThing().getConfiguration().get("extport").toString();
+            String hostname = Bridge.getHostPassword()[0];
+            String password = Bridge.getHostPassword()[1];
+            String port = Bridge.getThing().getConfiguration().get("port").toString();
+            String extport = getThing().getConfiguration().get("extport").toString();
             String result = "http://" + hostname + "/" + password + "/?cmd=" + port + "e" + extport + ":";
-			String idChannel = channelUID.getId();
+            String idChannel = channelUID.getId();
             switch (idChannel) {
                 case MegaDBindingConstants.CHANNEL_DIMMER:
                     switch (strCommand) {
@@ -135,7 +135,7 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
     @Override
     public void initialize() {
         Bridge = getBridgeHandler();
-		registerListenerThing(Bridge);
+        registerListenerThing(Bridge);
         if (Bridge != null) {
             while (!Bridge.getStateStarted()) {
                 try {
@@ -152,8 +152,8 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
         if (bridge != null) {
             bridge.registerListenerThing(this);
         } else {
-			logger.debug("Can't register bridge for {}. BridgeHandler is null.", this.getThing().getUID());
-		}
+            logger.debug("Can't register bridge for {}. BridgeHandler is null.", this.getThing().getUID());
+        }
     }
 
     public void updateValues(String action) {
@@ -229,7 +229,7 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
         }
     }
 
-	@SuppressWarnings({ "null" })
+    @SuppressWarnings({ "null" })
     protected void updateData(@Nullable String extport) {
         String hostname = Bridge.getHostPassword()[0];
         String password = Bridge.getHostPassword()[1];
@@ -308,8 +308,11 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
         } catch (ProtocolException e) {
             logger.error("{}", e.getLocalizedMessage());
         } catch (IOException e) {
-            logger.error("Connect to megadevice {} {} error: ", Bridge.getHostPassword()[0],
-                    e.getLocalizedMessage());
+            logger.error(
+				"Connect to megadevice {} {} error: ",
+				Bridge.getHostPassword()[0],
+				e.getLocalizedMessage()
+			);
         }
     }
 }

--- a/src/main/java/org/openhab/binding/megad/handler/MegaDExtenderPCA9685Handler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDExtenderPCA9685Handler.java
@@ -58,15 +58,14 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
     @SuppressWarnings("null")
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        String result = "";
-        String hostname = extenderPCA9685Bridge.getHostPassword()[0];
-        String password = extenderPCA9685Bridge.getHostPassword()[1];
-        String port = extenderPCA9685Bridge.getThing().getConfiguration().get("port").toString();
-        String extport = getThing().getConfiguration().get("extport").toString();
-        String strCommand = command.toString();
-        String idChannel = channelUID.getId();
+		String strCommand = command.toString();
         if (!strCommand.equals("REFRESH")) {
-            result = "http://" + hostname + "/" + password + "/?cmd=" + port + "e" + extport + ":";
+			String hostname = extenderPCA9685Bridge.getHostPassword()[0];
+			String password = extenderPCA9685Bridge.getHostPassword()[1];
+			String port = extenderPCA9685Bridge.getThing().getConfiguration().get("port").toString();
+			String extport = getThing().getConfiguration().get("extport").toString();
+            String result = "http://" + hostname + "/" + password + "/?cmd=" + port + "e" + extport + ":";
+			String idChannel = channelUID.getId();
             switch (idChannel) {
                 case MegaDBindingConstants.CHANNEL_DIMMER:
                     switch (strCommand) {
@@ -108,7 +107,7 @@ public class MegaDExtenderPCA9685Handler extends BaseThingHandler {
                 case MegaDBindingConstants.CHANNEL_PWM:
                     int currentValue = 0;
                     try {
-                        int uivalue = Integer.parseInt(command.toString().split("[.]")[0]);
+                        int uivalue = Integer.parseInt(strCommand.split("[.]")[0]);
                         if (uivalue != 0) {
                             currentValue = uivalue;
                         }


### PR DESCRIPTION
Команда &cmd=get может применяться к группе портов, а не только к конкретному порту, как написано "http://192.168.0.14/sec/?pt=31&ext=15&cmd=get". Переделал по примеру MCP230ХХ.

Начал оптимизировать имена переменных и методов