### PR TITLE
fix: bug in MegaDDeviceHandler.java

### DIFF
--- a/src/main/java/org/openhab/binding/megad/handler/MegaDDeviceHandler.java
+++ b/src/main/java/org/openhab/binding/megad/handler/MegaDDeviceHandler.java
@@ -119,16 +119,14 @@ public class MegaDDeviceHandler extends BaseBridgeHandler {
                 String ip = config.hostname.substring(0, config.hostname.lastIndexOf("."));
                 for (InetAddress address : MegaDService.interfacesAddresses) {
                     if (address.getHostAddress().startsWith(ip)) {
-                        if (MegaDService.interfacesAddresses.stream().findFirst().isPresent()) {
-                            if ((!megaDHardware.getSip()
-                                    .equals(MegaDService.interfacesAddresses.stream().findFirst().get().getHostAddress()
-                                            + ":" + MegaDService.port))
-                                    || (!megaDHardware.getSct().equals("megad"))) {
-                                httpHelper.request("http://" + config.hostname + "/" + config.password + "/?cf=1&sip="
-                                        + MegaDService.interfacesAddresses.stream().findFirst().get().getHostAddress()
-                                        + "%3A" + MegaDService.port + "&sct=megad&srvt=0");
-                            }
+                        if ((!megaDHardware.getSip()
+                                .equals(address.getHostAddress() + ":" + MegaDService.port))
+                                || (!megaDHardware.getSct().equals("megad"))) {
+                            httpHelper.request("http://" + config.hostname + "/" + config.password + "/?cf=1&sip="
+                                    + address.getHostAddress()
+                                    + "%3A" + MegaDService.port + "&sct=megad&srvt=0");
                         }
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Баг в MegaDDeviceHandler.java (строки 118-134): при setup=true биндинг правильно находил адрес в той же подсети что и MegaD (цикл + startsWith), но затем игнорировал его и брал findFirst() — первый адрес из списка всех интерфейсов. В Docker это всегда был случайный docker bridge адрес. Исправлено — теперь используется address из цикла, после нахождения совпадения цикл прерывается через break.